### PR TITLE
Cambia el nombre de MenuDia a PlanDia

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod info_nutricional;
 mod ingrediente;
 mod receta;
-mod menu_dia;
+mod plan_dia;
 
 fn main() {
     println!("Hello, world!");

--- a/src/plan_dia.rs
+++ b/src/plan_dia.rs
@@ -1,6 +1,6 @@
 use crate::receta::Receta;
 
-pub(crate) struct MenuDia {
+pub(crate) struct PlanDia {
     pub(crate) desayuno: Vec<Receta>,
     pub(crate) almuerzo: Vec<Receta>,
     pub(crate) cena: Vec<Receta>,


### PR DESCRIPTION
Se cambia el nombre pues menú da la impresión de ser 1 comida, en lugar de todas las comidas del día.